### PR TITLE
adjusted to the asset-cid changes of planetmint protobuf

### DIFF
--- a/lib/default/rddl/src/planetmintgo.c
+++ b/lib/default/rddl/src/planetmintgo.c
@@ -204,43 +204,14 @@ int generateAnyAttestMachineMsg(Google__Protobuf__Any* anyMsg, Planetmintgo__Mac
     return 0;
 }
 
-
-int generateAnyCIDAttestMsg( Google__Protobuf__Any* anyMsg, char *public_address )
-{
-    Planetmintgo__Asset__MsgNotarizeAsset msg = PLANETMINTGO__ASSET__MSG_NOTARIZE_ASSET__INIT;
-    msg.creator = public_address;
-    msg.hash = "cid";
-    msg.signature = "313d60b37ca2f168d33b7d6234f6d8725d910d0a74872350874bb0a98f8cc8584204010720b9d1dfe3800fdbf067d07bba13d2954d2e98943e18b8fe1fadf77b";
-    msg.pubkey = "02328de87896b9cbb5101c335f40029e4be898988b470abbf683f1a0b318d73470";
-
-    anyMsg->type_url = "/planetmintgo.asset.MsgNotarizeAsset";
-    anyMsg->value.len = planetmintgo__asset__msg_notarize_asset__get_packed_size(&msg);
-    anyMsg->value.data = getStack(anyMsg->value.len);
-    if( !anyMsg->value.data )
-        return -1;
-    planetmintgo__asset__msg_notarize_asset__pack(&msg, anyMsg->value.data);
-    return 0;
-}
-
-int generateAnyCIDAttestMsgGeneric( Google__Protobuf__Any* anyMsg, const char* cid, uint8_t* priv_key, uint8_t* pub_key, char* public_address, const char* ext_pub_key)
+int generateAnyCIDAttestMsg( Google__Protobuf__Any* anyMsg, const char* cid, uint8_t* priv_key, uint8_t* pub_key, char* public_address, const char* ext_pub_key)
 {
 
     Planetmintgo__Asset__MsgNotarizeAsset msg = PLANETMINTGO__ASSET__MSG_NOTARIZE_ASSET__INIT;
 
-    uint8_t digest[SHA256_DIGEST_LENGTH] = {0};
-    sha256(cid, strlen(cid), digest);
-
-    const ecdsa_curve *curve = &secp256k1;
-
-    uint8_t signature[64]= {0};
-    char signature_hex[64*2+1] = {0};
-    int res = ecdsa_sign_digest(curve, (const unsigned char *)priv_key, (const unsigned char *)digest, signature, NULL, NULL);
-    toHexString(signature_hex, signature, 128);
-
     msg.creator = public_address;
-    msg.hash = (char*)cid;
-    msg.signature =  signature_hex;
-    msg.pubkey = ext_pub_key;
+    msg.cid = (char*)cid;
+
 
     anyMsg->type_url = "/planetmintgo.asset.MsgNotarizeAsset";
     anyMsg->value.len = planetmintgo__asset__msg_notarize_asset__get_packed_size(&msg);

--- a/lib/default/rddl/src/planetmintgo.h
+++ b/lib/default/rddl/src/planetmintgo.h
@@ -23,12 +23,12 @@ bool get_address_info_from_accounts( const char* json_obj, const char* address, 
 void pubkey2address( const uint8_t* pubkey, size_t key_length, uint8_t* address);
 int getAddressString( const uint8_t* address, char* stringbuffer);
 
-int generateAnyCIDAttestMsg( Google__Protobuf__Any* anyMsg, char *public_address );
-int generateAnyCIDAttestMsgGeneric( Google__Protobuf__Any* anyMsg, const char* cid, 
+int generateAnyCIDAttestMsg( Google__Protobuf__Any* anyMsg, const char* cid, 
         uint8_t* priv_key, uint8_t* pub_key,
         char *public_address, const char* ext_pub_key);
 
-int generateAnyAttestMachineMsg(Google__Protobuf__Any* anyMsg, Planetmintgo__Machine__MsgAttestMachine* machineMsg);
+int generateAnyAttestMachineMsg(Google__Protobuf__Any* anyMsg, 
+        Planetmintgo__Machine__MsgAttestMachine* machineMsg);
 
 int prepareTx( Google__Protobuf__Any* anyMsg, 
         Cosmos__Base__V1beta1__Coin* coin,

--- a/lib/default/rddl/src/planetmintgo/asset/asset.pb-c.c
+++ b/lib/default/rddl/src/planetmintgo/asset/asset.pb-c.c
@@ -52,39 +52,15 @@ void   planetmintgo__asset__asset__free_unpacked
   assert(message->base.descriptor == &planetmintgo__asset__asset__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-static const ProtobufCFieldDescriptor planetmintgo__asset__asset__field_descriptors[3] =
+static const ProtobufCFieldDescriptor planetmintgo__asset__asset__field_descriptors[1] =
 {
   {
-    "hash",
+    "cid",
     1,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_STRING,
     0,   /* quantifier_offset */
-    offsetof(Planetmintgo__Asset__Asset, hash),
-    NULL,
-    &protobuf_c_empty_string,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "signature",
-    2,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_STRING,
-    0,   /* quantifier_offset */
-    offsetof(Planetmintgo__Asset__Asset, signature),
-    NULL,
-    &protobuf_c_empty_string,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "pubkey",
-    3,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_STRING,
-    0,   /* quantifier_offset */
-    offsetof(Planetmintgo__Asset__Asset, pubkey),
+    offsetof(Planetmintgo__Asset__Asset, cid),
     NULL,
     &protobuf_c_empty_string,
     0,             /* flags */
@@ -92,14 +68,12 @@ static const ProtobufCFieldDescriptor planetmintgo__asset__asset__field_descript
   },
 };
 static const unsigned planetmintgo__asset__asset__field_indices_by_name[] = {
-  0,   /* field[0] = hash */
-  2,   /* field[2] = pubkey */
-  1,   /* field[1] = signature */
+  0,   /* field[0] = cid */
 };
 static const ProtobufCIntRange planetmintgo__asset__asset__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 3 }
+  { 0, 1 }
 };
 const ProtobufCMessageDescriptor planetmintgo__asset__asset__descriptor =
 {
@@ -109,7 +83,7 @@ const ProtobufCMessageDescriptor planetmintgo__asset__asset__descriptor =
   "Planetmintgo__Asset__Asset",
   "planetmintgo.asset",
   sizeof(Planetmintgo__Asset__Asset),
-  3,
+  1,
   planetmintgo__asset__asset__field_descriptors,
   planetmintgo__asset__asset__field_indices_by_name,
   1,  planetmintgo__asset__asset__number_ranges,

--- a/lib/default/rddl/src/planetmintgo/asset/asset.pb-c.h
+++ b/lib/default/rddl/src/planetmintgo/asset/asset.pb-c.h
@@ -26,13 +26,11 @@ typedef struct Planetmintgo__Asset__Asset Planetmintgo__Asset__Asset;
 struct  Planetmintgo__Asset__Asset
 {
   ProtobufCMessage base;
-  char *hash;
-  char *signature;
-  char *pubkey;
+  char *cid;
 };
 #define PLANETMINTGO__ASSET__ASSET__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&planetmintgo__asset__asset__descriptor) \
-    , (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string }
+    , (char *)protobuf_c_empty_string }
 
 
 /* Planetmintgo__Asset__Asset methods */

--- a/lib/default/rddl/src/planetmintgo/asset/query.pb-c.c
+++ b/lib/default/rddl/src/planetmintgo/asset/query.pb-c.c
@@ -97,6 +97,186 @@ void   planetmintgo__asset__query_params_response__free_unpacked
   assert(message->base.descriptor == &planetmintgo__asset__query_params_response__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
+void   planetmintgo__asset__query_get_cids_by_address_request__init
+                     (Planetmintgo__Asset__QueryGetCIDsByAddressRequest         *message)
+{
+  static const Planetmintgo__Asset__QueryGetCIDsByAddressRequest init_value = PLANETMINTGO__ASSET__QUERY_GET_CIDS_BY_ADDRESS_REQUEST__INIT;
+  *message = init_value;
+}
+size_t planetmintgo__asset__query_get_cids_by_address_request__get_packed_size
+                     (const Planetmintgo__Asset__QueryGetCIDsByAddressRequest *message)
+{
+  assert(message->base.descriptor == &planetmintgo__asset__query_get_cids_by_address_request__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t planetmintgo__asset__query_get_cids_by_address_request__pack
+                     (const Planetmintgo__Asset__QueryGetCIDsByAddressRequest *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &planetmintgo__asset__query_get_cids_by_address_request__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t planetmintgo__asset__query_get_cids_by_address_request__pack_to_buffer
+                     (const Planetmintgo__Asset__QueryGetCIDsByAddressRequest *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &planetmintgo__asset__query_get_cids_by_address_request__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+Planetmintgo__Asset__QueryGetCIDsByAddressRequest *
+       planetmintgo__asset__query_get_cids_by_address_request__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (Planetmintgo__Asset__QueryGetCIDsByAddressRequest *)
+     protobuf_c_message_unpack (&planetmintgo__asset__query_get_cids_by_address_request__descriptor,
+                                allocator, len, data);
+}
+void   planetmintgo__asset__query_get_cids_by_address_request__free_unpacked
+                     (Planetmintgo__Asset__QueryGetCIDsByAddressRequest *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &planetmintgo__asset__query_get_cids_by_address_request__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   planetmintgo__asset__query_get_cids_by_address_response__init
+                     (Planetmintgo__Asset__QueryGetCIDsByAddressResponse         *message)
+{
+  static const Planetmintgo__Asset__QueryGetCIDsByAddressResponse init_value = PLANETMINTGO__ASSET__QUERY_GET_CIDS_BY_ADDRESS_RESPONSE__INIT;
+  *message = init_value;
+}
+size_t planetmintgo__asset__query_get_cids_by_address_response__get_packed_size
+                     (const Planetmintgo__Asset__QueryGetCIDsByAddressResponse *message)
+{
+  assert(message->base.descriptor == &planetmintgo__asset__query_get_cids_by_address_response__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t planetmintgo__asset__query_get_cids_by_address_response__pack
+                     (const Planetmintgo__Asset__QueryGetCIDsByAddressResponse *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &planetmintgo__asset__query_get_cids_by_address_response__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t planetmintgo__asset__query_get_cids_by_address_response__pack_to_buffer
+                     (const Planetmintgo__Asset__QueryGetCIDsByAddressResponse *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &planetmintgo__asset__query_get_cids_by_address_response__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+Planetmintgo__Asset__QueryGetCIDsByAddressResponse *
+       planetmintgo__asset__query_get_cids_by_address_response__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (Planetmintgo__Asset__QueryGetCIDsByAddressResponse *)
+     protobuf_c_message_unpack (&planetmintgo__asset__query_get_cids_by_address_response__descriptor,
+                                allocator, len, data);
+}
+void   planetmintgo__asset__query_get_cids_by_address_response__free_unpacked
+                     (Planetmintgo__Asset__QueryGetCIDsByAddressResponse *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &planetmintgo__asset__query_get_cids_by_address_response__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   planetmintgo__asset__query_get_notarized_asset_request__init
+                     (Planetmintgo__Asset__QueryGetNotarizedAssetRequest         *message)
+{
+  static const Planetmintgo__Asset__QueryGetNotarizedAssetRequest init_value = PLANETMINTGO__ASSET__QUERY_GET_NOTARIZED_ASSET_REQUEST__INIT;
+  *message = init_value;
+}
+size_t planetmintgo__asset__query_get_notarized_asset_request__get_packed_size
+                     (const Planetmintgo__Asset__QueryGetNotarizedAssetRequest *message)
+{
+  assert(message->base.descriptor == &planetmintgo__asset__query_get_notarized_asset_request__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t planetmintgo__asset__query_get_notarized_asset_request__pack
+                     (const Planetmintgo__Asset__QueryGetNotarizedAssetRequest *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &planetmintgo__asset__query_get_notarized_asset_request__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t planetmintgo__asset__query_get_notarized_asset_request__pack_to_buffer
+                     (const Planetmintgo__Asset__QueryGetNotarizedAssetRequest *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &planetmintgo__asset__query_get_notarized_asset_request__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+Planetmintgo__Asset__QueryGetNotarizedAssetRequest *
+       planetmintgo__asset__query_get_notarized_asset_request__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (Planetmintgo__Asset__QueryGetNotarizedAssetRequest *)
+     protobuf_c_message_unpack (&planetmintgo__asset__query_get_notarized_asset_request__descriptor,
+                                allocator, len, data);
+}
+void   planetmintgo__asset__query_get_notarized_asset_request__free_unpacked
+                     (Planetmintgo__Asset__QueryGetNotarizedAssetRequest *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &planetmintgo__asset__query_get_notarized_asset_request__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   planetmintgo__asset__query_get_notarized_asset_response__init
+                     (Planetmintgo__Asset__QueryGetNotarizedAssetResponse         *message)
+{
+  static const Planetmintgo__Asset__QueryGetNotarizedAssetResponse init_value = PLANETMINTGO__ASSET__QUERY_GET_NOTARIZED_ASSET_RESPONSE__INIT;
+  *message = init_value;
+}
+size_t planetmintgo__asset__query_get_notarized_asset_response__get_packed_size
+                     (const Planetmintgo__Asset__QueryGetNotarizedAssetResponse *message)
+{
+  assert(message->base.descriptor == &planetmintgo__asset__query_get_notarized_asset_response__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t planetmintgo__asset__query_get_notarized_asset_response__pack
+                     (const Planetmintgo__Asset__QueryGetNotarizedAssetResponse *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &planetmintgo__asset__query_get_notarized_asset_response__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t planetmintgo__asset__query_get_notarized_asset_response__pack_to_buffer
+                     (const Planetmintgo__Asset__QueryGetNotarizedAssetResponse *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &planetmintgo__asset__query_get_notarized_asset_response__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+Planetmintgo__Asset__QueryGetNotarizedAssetResponse *
+       planetmintgo__asset__query_get_notarized_asset_response__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (Planetmintgo__Asset__QueryGetNotarizedAssetResponse *)
+     protobuf_c_message_unpack (&planetmintgo__asset__query_get_notarized_asset_response__descriptor,
+                                allocator, len, data);
+}
+void   planetmintgo__asset__query_get_notarized_asset_response__free_unpacked
+                     (Planetmintgo__Asset__QueryGetNotarizedAssetResponse *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &planetmintgo__asset__query_get_notarized_asset_response__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
 #define planetmintgo__asset__query_params_request__field_descriptors NULL
 #define planetmintgo__asset__query_params_request__field_indices_by_name NULL
 #define planetmintgo__asset__query_params_request__number_ranges NULL
@@ -153,11 +333,219 @@ const ProtobufCMessageDescriptor planetmintgo__asset__query_params_response__des
   (ProtobufCMessageInit) planetmintgo__asset__query_params_response__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCMethodDescriptor planetmintgo__asset__query__method_descriptors[1] =
+static const ProtobufCFieldDescriptor planetmintgo__asset__query_get_cids_by_address_request__field_descriptors[3] =
+{
+  {
+    "address",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_STRING,
+    0,   /* quantifier_offset */
+    offsetof(Planetmintgo__Asset__QueryGetCIDsByAddressRequest, address),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "lookupPeriodInMin",
+    2,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_UINT64,
+    0,   /* quantifier_offset */
+    offsetof(Planetmintgo__Asset__QueryGetCIDsByAddressRequest, lookupperiodinmin),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "pagination",
+    3,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    0,   /* quantifier_offset */
+    offsetof(Planetmintgo__Asset__QueryGetCIDsByAddressRequest, pagination),
+    &cosmos__base__query__v1beta1__page_request__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned planetmintgo__asset__query_get_cids_by_address_request__field_indices_by_name[] = {
+  0,   /* field[0] = address */
+  1,   /* field[1] = lookupPeriodInMin */
+  2,   /* field[2] = pagination */
+};
+static const ProtobufCIntRange planetmintgo__asset__query_get_cids_by_address_request__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 3 }
+};
+const ProtobufCMessageDescriptor planetmintgo__asset__query_get_cids_by_address_request__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "planetmintgo.asset.QueryGetCIDsByAddressRequest",
+  "QueryGetCIDsByAddressRequest",
+  "Planetmintgo__Asset__QueryGetCIDsByAddressRequest",
+  "planetmintgo.asset",
+  sizeof(Planetmintgo__Asset__QueryGetCIDsByAddressRequest),
+  3,
+  planetmintgo__asset__query_get_cids_by_address_request__field_descriptors,
+  planetmintgo__asset__query_get_cids_by_address_request__field_indices_by_name,
+  1,  planetmintgo__asset__query_get_cids_by_address_request__number_ranges,
+  (ProtobufCMessageInit) planetmintgo__asset__query_get_cids_by_address_request__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor planetmintgo__asset__query_get_cids_by_address_response__field_descriptors[2] =
+{
+  {
+    "cids",
+    1,
+    PROTOBUF_C_LABEL_REPEATED,
+    PROTOBUF_C_TYPE_STRING,
+    offsetof(Planetmintgo__Asset__QueryGetCIDsByAddressResponse, n_cids),
+    offsetof(Planetmintgo__Asset__QueryGetCIDsByAddressResponse, cids),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "pagination",
+    2,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    0,   /* quantifier_offset */
+    offsetof(Planetmintgo__Asset__QueryGetCIDsByAddressResponse, pagination),
+    &cosmos__base__query__v1beta1__page_response__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned planetmintgo__asset__query_get_cids_by_address_response__field_indices_by_name[] = {
+  0,   /* field[0] = cids */
+  1,   /* field[1] = pagination */
+};
+static const ProtobufCIntRange planetmintgo__asset__query_get_cids_by_address_response__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 2 }
+};
+const ProtobufCMessageDescriptor planetmintgo__asset__query_get_cids_by_address_response__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "planetmintgo.asset.QueryGetCIDsByAddressResponse",
+  "QueryGetCIDsByAddressResponse",
+  "Planetmintgo__Asset__QueryGetCIDsByAddressResponse",
+  "planetmintgo.asset",
+  sizeof(Planetmintgo__Asset__QueryGetCIDsByAddressResponse),
+  2,
+  planetmintgo__asset__query_get_cids_by_address_response__field_descriptors,
+  planetmintgo__asset__query_get_cids_by_address_response__field_indices_by_name,
+  1,  planetmintgo__asset__query_get_cids_by_address_response__number_ranges,
+  (ProtobufCMessageInit) planetmintgo__asset__query_get_cids_by_address_response__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor planetmintgo__asset__query_get_notarized_asset_request__field_descriptors[1] =
+{
+  {
+    "cid",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_STRING,
+    0,   /* quantifier_offset */
+    offsetof(Planetmintgo__Asset__QueryGetNotarizedAssetRequest, cid),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned planetmintgo__asset__query_get_notarized_asset_request__field_indices_by_name[] = {
+  0,   /* field[0] = cid */
+};
+static const ProtobufCIntRange planetmintgo__asset__query_get_notarized_asset_request__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 1 }
+};
+const ProtobufCMessageDescriptor planetmintgo__asset__query_get_notarized_asset_request__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "planetmintgo.asset.QueryGetNotarizedAssetRequest",
+  "QueryGetNotarizedAssetRequest",
+  "Planetmintgo__Asset__QueryGetNotarizedAssetRequest",
+  "planetmintgo.asset",
+  sizeof(Planetmintgo__Asset__QueryGetNotarizedAssetRequest),
+  1,
+  planetmintgo__asset__query_get_notarized_asset_request__field_descriptors,
+  planetmintgo__asset__query_get_notarized_asset_request__field_indices_by_name,
+  1,  planetmintgo__asset__query_get_notarized_asset_request__number_ranges,
+  (ProtobufCMessageInit) planetmintgo__asset__query_get_notarized_asset_request__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor planetmintgo__asset__query_get_notarized_asset_response__field_descriptors[2] =
+{
+  {
+    "cid",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_STRING,
+    0,   /* quantifier_offset */
+    offsetof(Planetmintgo__Asset__QueryGetNotarizedAssetResponse, cid),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "address",
+    2,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_STRING,
+    0,   /* quantifier_offset */
+    offsetof(Planetmintgo__Asset__QueryGetNotarizedAssetResponse, address),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned planetmintgo__asset__query_get_notarized_asset_response__field_indices_by_name[] = {
+  1,   /* field[1] = address */
+  0,   /* field[0] = cid */
+};
+static const ProtobufCIntRange planetmintgo__asset__query_get_notarized_asset_response__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 2 }
+};
+const ProtobufCMessageDescriptor planetmintgo__asset__query_get_notarized_asset_response__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "planetmintgo.asset.QueryGetNotarizedAssetResponse",
+  "QueryGetNotarizedAssetResponse",
+  "Planetmintgo__Asset__QueryGetNotarizedAssetResponse",
+  "planetmintgo.asset",
+  sizeof(Planetmintgo__Asset__QueryGetNotarizedAssetResponse),
+  2,
+  planetmintgo__asset__query_get_notarized_asset_response__field_descriptors,
+  planetmintgo__asset__query_get_notarized_asset_response__field_indices_by_name,
+  1,  planetmintgo__asset__query_get_notarized_asset_response__number_ranges,
+  (ProtobufCMessageInit) planetmintgo__asset__query_get_notarized_asset_response__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCMethodDescriptor planetmintgo__asset__query__method_descriptors[3] =
 {
   { "Params", &planetmintgo__asset__query_params_request__descriptor, &planetmintgo__asset__query_params_response__descriptor },
+  { "GetCIDsByAddress", &planetmintgo__asset__query_get_cids_by_address_request__descriptor, &planetmintgo__asset__query_get_cids_by_address_response__descriptor },
+  { "GetNotarizedAsset", &planetmintgo__asset__query_get_notarized_asset_request__descriptor, &planetmintgo__asset__query_get_notarized_asset_response__descriptor },
 };
 const unsigned planetmintgo__asset__query__method_indices_by_name[] = {
+  1,        /* GetCIDsByAddress */
+  2,        /* GetNotarizedAsset */
   0         /* Params */
 };
 const ProtobufCServiceDescriptor planetmintgo__asset__query__descriptor =
@@ -167,7 +555,7 @@ const ProtobufCServiceDescriptor planetmintgo__asset__query__descriptor =
   "Query",
   "Planetmintgo__Asset__Query",
   "planetmintgo.asset",
-  1,
+  3,
   planetmintgo__asset__query__method_descriptors,
   planetmintgo__asset__query__method_indices_by_name
 };
@@ -178,6 +566,22 @@ void planetmintgo__asset__query__params(ProtobufCService *service,
 {
   assert(service->descriptor == &planetmintgo__asset__query__descriptor);
   service->invoke(service, 0, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
+}
+void planetmintgo__asset__query__get_cids_by_address(ProtobufCService *service,
+                                                     const Planetmintgo__Asset__QueryGetCIDsByAddressRequest *input,
+                                                     Planetmintgo__Asset__QueryGetCIDsByAddressResponse_Closure closure,
+                                                     void *closure_data)
+{
+  assert(service->descriptor == &planetmintgo__asset__query__descriptor);
+  service->invoke(service, 1, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
+}
+void planetmintgo__asset__query__get_notarized_asset(ProtobufCService *service,
+                                                     const Planetmintgo__Asset__QueryGetNotarizedAssetRequest *input,
+                                                     Planetmintgo__Asset__QueryGetNotarizedAssetResponse_Closure closure,
+                                                     void *closure_data)
+{
+  assert(service->descriptor == &planetmintgo__asset__query__descriptor);
+  service->invoke(service, 2, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
 }
 void planetmintgo__asset__query__init (Planetmintgo__Asset__Query_Service *service,
                                        Planetmintgo__Asset__Query_ServiceDestroy destroy)

--- a/lib/default/rddl/src/planetmintgo/asset/query.pb-c.h
+++ b/lib/default/rddl/src/planetmintgo/asset/query.pb-c.h
@@ -21,6 +21,10 @@ PROTOBUF_C__BEGIN_DECLS
 
 typedef struct Planetmintgo__Asset__QueryParamsRequest Planetmintgo__Asset__QueryParamsRequest;
 typedef struct Planetmintgo__Asset__QueryParamsResponse Planetmintgo__Asset__QueryParamsResponse;
+typedef struct Planetmintgo__Asset__QueryGetCIDsByAddressRequest Planetmintgo__Asset__QueryGetCIDsByAddressRequest;
+typedef struct Planetmintgo__Asset__QueryGetCIDsByAddressResponse Planetmintgo__Asset__QueryGetCIDsByAddressResponse;
+typedef struct Planetmintgo__Asset__QueryGetNotarizedAssetRequest Planetmintgo__Asset__QueryGetNotarizedAssetRequest;
+typedef struct Planetmintgo__Asset__QueryGetNotarizedAssetResponse Planetmintgo__Asset__QueryGetNotarizedAssetResponse;
 
 
 /* --- enums --- */
@@ -54,6 +58,51 @@ struct  Planetmintgo__Asset__QueryParamsResponse
 #define PLANETMINTGO__ASSET__QUERY_PARAMS_RESPONSE__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&planetmintgo__asset__query_params_response__descriptor) \
     , NULL }
+
+
+struct  Planetmintgo__Asset__QueryGetCIDsByAddressRequest
+{
+  ProtobufCMessage base;
+  char *address;
+  uint64_t lookupperiodinmin;
+  Cosmos__Base__Query__V1beta1__PageRequest *pagination;
+};
+#define PLANETMINTGO__ASSET__QUERY_GET_CIDS_BY_ADDRESS_REQUEST__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&planetmintgo__asset__query_get_cids_by_address_request__descriptor) \
+    , (char *)protobuf_c_empty_string, 0, NULL }
+
+
+struct  Planetmintgo__Asset__QueryGetCIDsByAddressResponse
+{
+  ProtobufCMessage base;
+  size_t n_cids;
+  char **cids;
+  Cosmos__Base__Query__V1beta1__PageResponse *pagination;
+};
+#define PLANETMINTGO__ASSET__QUERY_GET_CIDS_BY_ADDRESS_RESPONSE__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&planetmintgo__asset__query_get_cids_by_address_response__descriptor) \
+    , 0,NULL, NULL }
+
+
+struct  Planetmintgo__Asset__QueryGetNotarizedAssetRequest
+{
+  ProtobufCMessage base;
+  char *cid;
+};
+#define PLANETMINTGO__ASSET__QUERY_GET_NOTARIZED_ASSET_REQUEST__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&planetmintgo__asset__query_get_notarized_asset_request__descriptor) \
+    , (char *)protobuf_c_empty_string }
+
+
+struct  Planetmintgo__Asset__QueryGetNotarizedAssetResponse
+{
+  ProtobufCMessage base;
+  char *cid;
+  char *address;
+};
+#define PLANETMINTGO__ASSET__QUERY_GET_NOTARIZED_ASSET_RESPONSE__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&planetmintgo__asset__query_get_notarized_asset_response__descriptor) \
+    , (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string }
 
 
 /* Planetmintgo__Asset__QueryParamsRequest methods */
@@ -94,6 +143,82 @@ Planetmintgo__Asset__QueryParamsResponse *
 void   planetmintgo__asset__query_params_response__free_unpacked
                      (Planetmintgo__Asset__QueryParamsResponse *message,
                       ProtobufCAllocator *allocator);
+/* Planetmintgo__Asset__QueryGetCIDsByAddressRequest methods */
+void   planetmintgo__asset__query_get_cids_by_address_request__init
+                     (Planetmintgo__Asset__QueryGetCIDsByAddressRequest         *message);
+size_t planetmintgo__asset__query_get_cids_by_address_request__get_packed_size
+                     (const Planetmintgo__Asset__QueryGetCIDsByAddressRequest   *message);
+size_t planetmintgo__asset__query_get_cids_by_address_request__pack
+                     (const Planetmintgo__Asset__QueryGetCIDsByAddressRequest   *message,
+                      uint8_t             *out);
+size_t planetmintgo__asset__query_get_cids_by_address_request__pack_to_buffer
+                     (const Planetmintgo__Asset__QueryGetCIDsByAddressRequest   *message,
+                      ProtobufCBuffer     *buffer);
+Planetmintgo__Asset__QueryGetCIDsByAddressRequest *
+       planetmintgo__asset__query_get_cids_by_address_request__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   planetmintgo__asset__query_get_cids_by_address_request__free_unpacked
+                     (Planetmintgo__Asset__QueryGetCIDsByAddressRequest *message,
+                      ProtobufCAllocator *allocator);
+/* Planetmintgo__Asset__QueryGetCIDsByAddressResponse methods */
+void   planetmintgo__asset__query_get_cids_by_address_response__init
+                     (Planetmintgo__Asset__QueryGetCIDsByAddressResponse         *message);
+size_t planetmintgo__asset__query_get_cids_by_address_response__get_packed_size
+                     (const Planetmintgo__Asset__QueryGetCIDsByAddressResponse   *message);
+size_t planetmintgo__asset__query_get_cids_by_address_response__pack
+                     (const Planetmintgo__Asset__QueryGetCIDsByAddressResponse   *message,
+                      uint8_t             *out);
+size_t planetmintgo__asset__query_get_cids_by_address_response__pack_to_buffer
+                     (const Planetmintgo__Asset__QueryGetCIDsByAddressResponse   *message,
+                      ProtobufCBuffer     *buffer);
+Planetmintgo__Asset__QueryGetCIDsByAddressResponse *
+       planetmintgo__asset__query_get_cids_by_address_response__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   planetmintgo__asset__query_get_cids_by_address_response__free_unpacked
+                     (Planetmintgo__Asset__QueryGetCIDsByAddressResponse *message,
+                      ProtobufCAllocator *allocator);
+/* Planetmintgo__Asset__QueryGetNotarizedAssetRequest methods */
+void   planetmintgo__asset__query_get_notarized_asset_request__init
+                     (Planetmintgo__Asset__QueryGetNotarizedAssetRequest         *message);
+size_t planetmintgo__asset__query_get_notarized_asset_request__get_packed_size
+                     (const Planetmintgo__Asset__QueryGetNotarizedAssetRequest   *message);
+size_t planetmintgo__asset__query_get_notarized_asset_request__pack
+                     (const Planetmintgo__Asset__QueryGetNotarizedAssetRequest   *message,
+                      uint8_t             *out);
+size_t planetmintgo__asset__query_get_notarized_asset_request__pack_to_buffer
+                     (const Planetmintgo__Asset__QueryGetNotarizedAssetRequest   *message,
+                      ProtobufCBuffer     *buffer);
+Planetmintgo__Asset__QueryGetNotarizedAssetRequest *
+       planetmintgo__asset__query_get_notarized_asset_request__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   planetmintgo__asset__query_get_notarized_asset_request__free_unpacked
+                     (Planetmintgo__Asset__QueryGetNotarizedAssetRequest *message,
+                      ProtobufCAllocator *allocator);
+/* Planetmintgo__Asset__QueryGetNotarizedAssetResponse methods */
+void   planetmintgo__asset__query_get_notarized_asset_response__init
+                     (Planetmintgo__Asset__QueryGetNotarizedAssetResponse         *message);
+size_t planetmintgo__asset__query_get_notarized_asset_response__get_packed_size
+                     (const Planetmintgo__Asset__QueryGetNotarizedAssetResponse   *message);
+size_t planetmintgo__asset__query_get_notarized_asset_response__pack
+                     (const Planetmintgo__Asset__QueryGetNotarizedAssetResponse   *message,
+                      uint8_t             *out);
+size_t planetmintgo__asset__query_get_notarized_asset_response__pack_to_buffer
+                     (const Planetmintgo__Asset__QueryGetNotarizedAssetResponse   *message,
+                      ProtobufCBuffer     *buffer);
+Planetmintgo__Asset__QueryGetNotarizedAssetResponse *
+       planetmintgo__asset__query_get_notarized_asset_response__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   planetmintgo__asset__query_get_notarized_asset_response__free_unpacked
+                     (Planetmintgo__Asset__QueryGetNotarizedAssetResponse *message,
+                      ProtobufCAllocator *allocator);
 /* --- per-message closures --- */
 
 typedef void (*Planetmintgo__Asset__QueryParamsRequest_Closure)
@@ -101,6 +226,18 @@ typedef void (*Planetmintgo__Asset__QueryParamsRequest_Closure)
                   void *closure_data);
 typedef void (*Planetmintgo__Asset__QueryParamsResponse_Closure)
                  (const Planetmintgo__Asset__QueryParamsResponse *message,
+                  void *closure_data);
+typedef void (*Planetmintgo__Asset__QueryGetCIDsByAddressRequest_Closure)
+                 (const Planetmintgo__Asset__QueryGetCIDsByAddressRequest *message,
+                  void *closure_data);
+typedef void (*Planetmintgo__Asset__QueryGetCIDsByAddressResponse_Closure)
+                 (const Planetmintgo__Asset__QueryGetCIDsByAddressResponse *message,
+                  void *closure_data);
+typedef void (*Planetmintgo__Asset__QueryGetNotarizedAssetRequest_Closure)
+                 (const Planetmintgo__Asset__QueryGetNotarizedAssetRequest *message,
+                  void *closure_data);
+typedef void (*Planetmintgo__Asset__QueryGetNotarizedAssetResponse_Closure)
+                 (const Planetmintgo__Asset__QueryGetNotarizedAssetResponse *message,
                   void *closure_data);
 
 /* --- services --- */
@@ -113,6 +250,14 @@ struct Planetmintgo__Asset__Query_Service
                  const Planetmintgo__Asset__QueryParamsRequest *input,
                  Planetmintgo__Asset__QueryParamsResponse_Closure closure,
                  void *closure_data);
+  void (*get_cids_by_address)(Planetmintgo__Asset__Query_Service *service,
+                              const Planetmintgo__Asset__QueryGetCIDsByAddressRequest *input,
+                              Planetmintgo__Asset__QueryGetCIDsByAddressResponse_Closure closure,
+                              void *closure_data);
+  void (*get_notarized_asset)(Planetmintgo__Asset__Query_Service *service,
+                              const Planetmintgo__Asset__QueryGetNotarizedAssetRequest *input,
+                              Planetmintgo__Asset__QueryGetNotarizedAssetResponse_Closure closure,
+                              void *closure_data);
 };
 typedef void (*Planetmintgo__Asset__Query_ServiceDestroy)(Planetmintgo__Asset__Query_Service *);
 void planetmintgo__asset__query__init (Planetmintgo__Asset__Query_Service *service,
@@ -121,16 +266,30 @@ void planetmintgo__asset__query__init (Planetmintgo__Asset__Query_Service *servi
     { &planetmintgo__asset__query__descriptor, protobuf_c_service_invoke_internal, NULL }
 #define PLANETMINTGO__ASSET__QUERY__INIT(function_prefix__) \
     { PLANETMINTGO__ASSET__QUERY__BASE_INIT,\
-      function_prefix__ ## params  }
+      function_prefix__ ## params,\
+      function_prefix__ ## get_cids_by_address,\
+      function_prefix__ ## get_notarized_asset  }
 void planetmintgo__asset__query__params(ProtobufCService *service,
                                         const Planetmintgo__Asset__QueryParamsRequest *input,
                                         Planetmintgo__Asset__QueryParamsResponse_Closure closure,
                                         void *closure_data);
+void planetmintgo__asset__query__get_cids_by_address(ProtobufCService *service,
+                                                     const Planetmintgo__Asset__QueryGetCIDsByAddressRequest *input,
+                                                     Planetmintgo__Asset__QueryGetCIDsByAddressResponse_Closure closure,
+                                                     void *closure_data);
+void planetmintgo__asset__query__get_notarized_asset(ProtobufCService *service,
+                                                     const Planetmintgo__Asset__QueryGetNotarizedAssetRequest *input,
+                                                     Planetmintgo__Asset__QueryGetNotarizedAssetResponse_Closure closure,
+                                                     void *closure_data);
 
 /* --- descriptors --- */
 
 extern const ProtobufCMessageDescriptor planetmintgo__asset__query_params_request__descriptor;
 extern const ProtobufCMessageDescriptor planetmintgo__asset__query_params_response__descriptor;
+extern const ProtobufCMessageDescriptor planetmintgo__asset__query_get_cids_by_address_request__descriptor;
+extern const ProtobufCMessageDescriptor planetmintgo__asset__query_get_cids_by_address_response__descriptor;
+extern const ProtobufCMessageDescriptor planetmintgo__asset__query_get_notarized_asset_request__descriptor;
+extern const ProtobufCMessageDescriptor planetmintgo__asset__query_get_notarized_asset_response__descriptor;
 extern const ProtobufCServiceDescriptor planetmintgo__asset__query__descriptor;
 
 PROTOBUF_C__END_DECLS

--- a/lib/default/rddl/src/planetmintgo/asset/tx.pb-c.c
+++ b/lib/default/rddl/src/planetmintgo/asset/tx.pb-c.c
@@ -97,7 +97,7 @@ void   planetmintgo__asset__msg_notarize_asset_response__free_unpacked
   assert(message->base.descriptor == &planetmintgo__asset__msg_notarize_asset_response__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-static const ProtobufCFieldDescriptor planetmintgo__asset__msg_notarize_asset__field_descriptors[4] =
+static const ProtobufCFieldDescriptor planetmintgo__asset__msg_notarize_asset__field_descriptors[2] =
 {
   {
     "creator",
@@ -112,36 +112,12 @@ static const ProtobufCFieldDescriptor planetmintgo__asset__msg_notarize_asset__f
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "hash",
+    "cid",
     2,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_STRING,
     0,   /* quantifier_offset */
-    offsetof(Planetmintgo__Asset__MsgNotarizeAsset, hash),
-    NULL,
-    &protobuf_c_empty_string,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "signature",
-    3,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_STRING,
-    0,   /* quantifier_offset */
-    offsetof(Planetmintgo__Asset__MsgNotarizeAsset, signature),
-    NULL,
-    &protobuf_c_empty_string,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "pubKey",
-    4,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_STRING,
-    0,   /* quantifier_offset */
-    offsetof(Planetmintgo__Asset__MsgNotarizeAsset, pubkey),
+    offsetof(Planetmintgo__Asset__MsgNotarizeAsset, cid),
     NULL,
     &protobuf_c_empty_string,
     0,             /* flags */
@@ -149,15 +125,13 @@ static const ProtobufCFieldDescriptor planetmintgo__asset__msg_notarize_asset__f
   },
 };
 static const unsigned planetmintgo__asset__msg_notarize_asset__field_indices_by_name[] = {
+  1,   /* field[1] = cid */
   0,   /* field[0] = creator */
-  1,   /* field[1] = hash */
-  3,   /* field[3] = pubKey */
-  2,   /* field[2] = signature */
 };
 static const ProtobufCIntRange planetmintgo__asset__msg_notarize_asset__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 4 }
+  { 0, 2 }
 };
 const ProtobufCMessageDescriptor planetmintgo__asset__msg_notarize_asset__descriptor =
 {
@@ -167,7 +141,7 @@ const ProtobufCMessageDescriptor planetmintgo__asset__msg_notarize_asset__descri
   "Planetmintgo__Asset__MsgNotarizeAsset",
   "planetmintgo.asset",
   sizeof(Planetmintgo__Asset__MsgNotarizeAsset),
-  4,
+  2,
   planetmintgo__asset__msg_notarize_asset__field_descriptors,
   planetmintgo__asset__msg_notarize_asset__field_indices_by_name,
   1,  planetmintgo__asset__msg_notarize_asset__number_ranges,

--- a/lib/default/rddl/src/planetmintgo/asset/tx.pb-c.h
+++ b/lib/default/rddl/src/planetmintgo/asset/tx.pb-c.h
@@ -28,13 +28,11 @@ struct  Planetmintgo__Asset__MsgNotarizeAsset
 {
   ProtobufCMessage base;
   char *creator;
-  char *hash;
-  char *signature;
-  char *pubkey;
+  char *cid;
 };
 #define PLANETMINTGO__ASSET__MSG_NOTARIZE_ASSET__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&planetmintgo__asset__msg_notarize_asset__descriptor) \
-    , (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string }
+    , (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string }
 
 
 struct  Planetmintgo__Asset__MsgNotarizeAssetResponse

--- a/lib/default/rddl/src/planetmintgo/machine/machine.pb-c.c
+++ b/lib/default/rddl/src/planetmintgo/machine/machine.pb-c.c
@@ -142,7 +142,7 @@ void   planetmintgo__machine__machine_index__free_unpacked
   assert(message->base.descriptor == &planetmintgo__machine__machine_index__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-static const ProtobufCFieldDescriptor planetmintgo__machine__machine__field_descriptors[12] =
+static const ProtobufCFieldDescriptor planetmintgo__machine__machine__field_descriptors[13] =
 {
   {
     "name",
@@ -288,8 +288,21 @@ static const ProtobufCFieldDescriptor planetmintgo__machine__machine__field_desc
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
+  {
+    "address",
+    13,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_STRING,
+    0,   /* quantifier_offset */
+    offsetof(Planetmintgo__Machine__Machine, address),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
 };
 static const unsigned planetmintgo__machine__machine__field_indices_by_name[] = {
+  12,   /* field[12] = address */
   4,   /* field[4] = amount */
   2,   /* field[2] = domain */
   7,   /* field[7] = issuerLiquid */
@@ -306,7 +319,7 @@ static const unsigned planetmintgo__machine__machine__field_indices_by_name[] = 
 static const ProtobufCIntRange planetmintgo__machine__machine__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 12 }
+  { 0, 13 }
 };
 const ProtobufCMessageDescriptor planetmintgo__machine__machine__descriptor =
 {
@@ -316,7 +329,7 @@ const ProtobufCMessageDescriptor planetmintgo__machine__machine__descriptor =
   "Planetmintgo__Machine__Machine",
   "planetmintgo.machine",
   sizeof(Planetmintgo__Machine__Machine),
-  12,
+  13,
   planetmintgo__machine__machine__field_descriptors,
   planetmintgo__machine__machine__field_indices_by_name,
   1,  planetmintgo__machine__machine__number_ranges,
@@ -400,7 +413,7 @@ const ProtobufCMessageDescriptor planetmintgo__machine__metadata__descriptor =
   (ProtobufCMessageInit) planetmintgo__machine__metadata__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor planetmintgo__machine__machine_index__field_descriptors[3] =
+static const ProtobufCFieldDescriptor planetmintgo__machine__machine_index__field_descriptors[4] =
 {
   {
     "machineId",
@@ -438,8 +451,21 @@ static const ProtobufCFieldDescriptor planetmintgo__machine__machine_index__fiel
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
+  {
+    "address",
+    4,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_STRING,
+    0,   /* quantifier_offset */
+    offsetof(Planetmintgo__Machine__MachineIndex, address),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
 };
 static const unsigned planetmintgo__machine__machine_index__field_indices_by_name[] = {
+  3,   /* field[3] = address */
   2,   /* field[2] = issuerLiquid */
   1,   /* field[1] = issuerPlanetmint */
   0,   /* field[0] = machineId */
@@ -447,7 +473,7 @@ static const unsigned planetmintgo__machine__machine_index__field_indices_by_nam
 static const ProtobufCIntRange planetmintgo__machine__machine_index__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 3 }
+  { 0, 4 }
 };
 const ProtobufCMessageDescriptor planetmintgo__machine__machine_index__descriptor =
 {
@@ -457,7 +483,7 @@ const ProtobufCMessageDescriptor planetmintgo__machine__machine_index__descripto
   "Planetmintgo__Machine__MachineIndex",
   "planetmintgo.machine",
   sizeof(Planetmintgo__Machine__MachineIndex),
-  3,
+  4,
   planetmintgo__machine__machine_index__field_descriptors,
   planetmintgo__machine__machine_index__field_indices_by_name,
   1,  planetmintgo__machine__machine_index__number_ranges,

--- a/lib/default/rddl/src/planetmintgo/machine/machine.pb-c.h
+++ b/lib/default/rddl/src/planetmintgo/machine/machine.pb-c.h
@@ -40,10 +40,11 @@ struct  Planetmintgo__Machine__Machine
   Planetmintgo__Machine__Metadata *metadata;
   uint32_t type;
   char *machineidsignature;
+  char *address;
 };
 #define PLANETMINTGO__MACHINE__MACHINE__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&planetmintgo__machine__machine__descriptor) \
-    , (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, 0, 0, 0, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, NULL, 0, (char *)protobuf_c_empty_string }
+    , (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, 0, 0, 0, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, NULL, 0, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string }
 
 
 struct  Planetmintgo__Machine__Metadata
@@ -65,10 +66,11 @@ struct  Planetmintgo__Machine__MachineIndex
   char *machineid;
   char *issuerplanetmint;
   char *issuerliquid;
+  char *address;
 };
 #define PLANETMINTGO__MACHINE__MACHINE_INDEX__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&planetmintgo__machine__machine_index__descriptor) \
-    , (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string }
+    , (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string }
 
 
 /* Planetmintgo__Machine__Machine methods */

--- a/lib/default/rddl/src/planetmintgo/machine/query.pb-c.c
+++ b/lib/default/rddl/src/planetmintgo/machine/query.pb-c.c
@@ -187,6 +187,186 @@ void   planetmintgo__machine__query_get_machine_by_public_key_response__free_unp
   assert(message->base.descriptor == &planetmintgo__machine__query_get_machine_by_public_key_response__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
+void   planetmintgo__machine__query_get_trust_anchor_status_request__init
+                     (Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest         *message)
+{
+  static const Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest init_value = PLANETMINTGO__MACHINE__QUERY_GET_TRUST_ANCHOR_STATUS_REQUEST__INIT;
+  *message = init_value;
+}
+size_t planetmintgo__machine__query_get_trust_anchor_status_request__get_packed_size
+                     (const Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest *message)
+{
+  assert(message->base.descriptor == &planetmintgo__machine__query_get_trust_anchor_status_request__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t planetmintgo__machine__query_get_trust_anchor_status_request__pack
+                     (const Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &planetmintgo__machine__query_get_trust_anchor_status_request__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t planetmintgo__machine__query_get_trust_anchor_status_request__pack_to_buffer
+                     (const Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &planetmintgo__machine__query_get_trust_anchor_status_request__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest *
+       planetmintgo__machine__query_get_trust_anchor_status_request__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest *)
+     protobuf_c_message_unpack (&planetmintgo__machine__query_get_trust_anchor_status_request__descriptor,
+                                allocator, len, data);
+}
+void   planetmintgo__machine__query_get_trust_anchor_status_request__free_unpacked
+                     (Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &planetmintgo__machine__query_get_trust_anchor_status_request__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   planetmintgo__machine__query_get_trust_anchor_status_response__init
+                     (Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse         *message)
+{
+  static const Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse init_value = PLANETMINTGO__MACHINE__QUERY_GET_TRUST_ANCHOR_STATUS_RESPONSE__INIT;
+  *message = init_value;
+}
+size_t planetmintgo__machine__query_get_trust_anchor_status_response__get_packed_size
+                     (const Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse *message)
+{
+  assert(message->base.descriptor == &planetmintgo__machine__query_get_trust_anchor_status_response__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t planetmintgo__machine__query_get_trust_anchor_status_response__pack
+                     (const Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &planetmintgo__machine__query_get_trust_anchor_status_response__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t planetmintgo__machine__query_get_trust_anchor_status_response__pack_to_buffer
+                     (const Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &planetmintgo__machine__query_get_trust_anchor_status_response__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse *
+       planetmintgo__machine__query_get_trust_anchor_status_response__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse *)
+     protobuf_c_message_unpack (&planetmintgo__machine__query_get_trust_anchor_status_response__descriptor,
+                                allocator, len, data);
+}
+void   planetmintgo__machine__query_get_trust_anchor_status_response__free_unpacked
+                     (Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &planetmintgo__machine__query_get_trust_anchor_status_response__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   planetmintgo__machine__query_get_machine_by_address_request__init
+                     (Planetmintgo__Machine__QueryGetMachineByAddressRequest         *message)
+{
+  static const Planetmintgo__Machine__QueryGetMachineByAddressRequest init_value = PLANETMINTGO__MACHINE__QUERY_GET_MACHINE_BY_ADDRESS_REQUEST__INIT;
+  *message = init_value;
+}
+size_t planetmintgo__machine__query_get_machine_by_address_request__get_packed_size
+                     (const Planetmintgo__Machine__QueryGetMachineByAddressRequest *message)
+{
+  assert(message->base.descriptor == &planetmintgo__machine__query_get_machine_by_address_request__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t planetmintgo__machine__query_get_machine_by_address_request__pack
+                     (const Planetmintgo__Machine__QueryGetMachineByAddressRequest *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &planetmintgo__machine__query_get_machine_by_address_request__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t planetmintgo__machine__query_get_machine_by_address_request__pack_to_buffer
+                     (const Planetmintgo__Machine__QueryGetMachineByAddressRequest *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &planetmintgo__machine__query_get_machine_by_address_request__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+Planetmintgo__Machine__QueryGetMachineByAddressRequest *
+       planetmintgo__machine__query_get_machine_by_address_request__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (Planetmintgo__Machine__QueryGetMachineByAddressRequest *)
+     protobuf_c_message_unpack (&planetmintgo__machine__query_get_machine_by_address_request__descriptor,
+                                allocator, len, data);
+}
+void   planetmintgo__machine__query_get_machine_by_address_request__free_unpacked
+                     (Planetmintgo__Machine__QueryGetMachineByAddressRequest *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &planetmintgo__machine__query_get_machine_by_address_request__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   planetmintgo__machine__query_get_machine_by_address_response__init
+                     (Planetmintgo__Machine__QueryGetMachineByAddressResponse         *message)
+{
+  static const Planetmintgo__Machine__QueryGetMachineByAddressResponse init_value = PLANETMINTGO__MACHINE__QUERY_GET_MACHINE_BY_ADDRESS_RESPONSE__INIT;
+  *message = init_value;
+}
+size_t planetmintgo__machine__query_get_machine_by_address_response__get_packed_size
+                     (const Planetmintgo__Machine__QueryGetMachineByAddressResponse *message)
+{
+  assert(message->base.descriptor == &planetmintgo__machine__query_get_machine_by_address_response__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t planetmintgo__machine__query_get_machine_by_address_response__pack
+                     (const Planetmintgo__Machine__QueryGetMachineByAddressResponse *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &planetmintgo__machine__query_get_machine_by_address_response__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t planetmintgo__machine__query_get_machine_by_address_response__pack_to_buffer
+                     (const Planetmintgo__Machine__QueryGetMachineByAddressResponse *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &planetmintgo__machine__query_get_machine_by_address_response__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+Planetmintgo__Machine__QueryGetMachineByAddressResponse *
+       planetmintgo__machine__query_get_machine_by_address_response__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (Planetmintgo__Machine__QueryGetMachineByAddressResponse *)
+     protobuf_c_message_unpack (&planetmintgo__machine__query_get_machine_by_address_response__descriptor,
+                                allocator, len, data);
+}
+void   planetmintgo__machine__query_get_machine_by_address_response__free_unpacked
+                     (Planetmintgo__Machine__QueryGetMachineByAddressResponse *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &planetmintgo__machine__query_get_machine_by_address_response__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
 #define planetmintgo__machine__query_params_request__field_descriptors NULL
 #define planetmintgo__machine__query_params_request__field_indices_by_name NULL
 #define planetmintgo__machine__query_params_request__number_ranges NULL
@@ -319,13 +499,182 @@ const ProtobufCMessageDescriptor planetmintgo__machine__query_get_machine_by_pub
   (ProtobufCMessageInit) planetmintgo__machine__query_get_machine_by_public_key_response__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCMethodDescriptor planetmintgo__machine__query__method_descriptors[2] =
+static const ProtobufCFieldDescriptor planetmintgo__machine__query_get_trust_anchor_status_request__field_descriptors[1] =
+{
+  {
+    "machineid",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_STRING,
+    0,   /* quantifier_offset */
+    offsetof(Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest, machineid),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned planetmintgo__machine__query_get_trust_anchor_status_request__field_indices_by_name[] = {
+  0,   /* field[0] = machineid */
+};
+static const ProtobufCIntRange planetmintgo__machine__query_get_trust_anchor_status_request__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 1 }
+};
+const ProtobufCMessageDescriptor planetmintgo__machine__query_get_trust_anchor_status_request__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "planetmintgo.machine.QueryGetTrustAnchorStatusRequest",
+  "QueryGetTrustAnchorStatusRequest",
+  "Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest",
+  "planetmintgo.machine",
+  sizeof(Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest),
+  1,
+  planetmintgo__machine__query_get_trust_anchor_status_request__field_descriptors,
+  planetmintgo__machine__query_get_trust_anchor_status_request__field_indices_by_name,
+  1,  planetmintgo__machine__query_get_trust_anchor_status_request__number_ranges,
+  (ProtobufCMessageInit) planetmintgo__machine__query_get_trust_anchor_status_request__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor planetmintgo__machine__query_get_trust_anchor_status_response__field_descriptors[2] =
+{
+  {
+    "machineid",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_STRING,
+    0,   /* quantifier_offset */
+    offsetof(Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse, machineid),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "isactivated",
+    2,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_BOOL,
+    0,   /* quantifier_offset */
+    offsetof(Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse, isactivated),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned planetmintgo__machine__query_get_trust_anchor_status_response__field_indices_by_name[] = {
+  1,   /* field[1] = isactivated */
+  0,   /* field[0] = machineid */
+};
+static const ProtobufCIntRange planetmintgo__machine__query_get_trust_anchor_status_response__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 2 }
+};
+const ProtobufCMessageDescriptor planetmintgo__machine__query_get_trust_anchor_status_response__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "planetmintgo.machine.QueryGetTrustAnchorStatusResponse",
+  "QueryGetTrustAnchorStatusResponse",
+  "Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse",
+  "planetmintgo.machine",
+  sizeof(Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse),
+  2,
+  planetmintgo__machine__query_get_trust_anchor_status_response__field_descriptors,
+  planetmintgo__machine__query_get_trust_anchor_status_response__field_indices_by_name,
+  1,  planetmintgo__machine__query_get_trust_anchor_status_response__number_ranges,
+  (ProtobufCMessageInit) planetmintgo__machine__query_get_trust_anchor_status_response__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor planetmintgo__machine__query_get_machine_by_address_request__field_descriptors[1] =
+{
+  {
+    "address",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_STRING,
+    0,   /* quantifier_offset */
+    offsetof(Planetmintgo__Machine__QueryGetMachineByAddressRequest, address),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned planetmintgo__machine__query_get_machine_by_address_request__field_indices_by_name[] = {
+  0,   /* field[0] = address */
+};
+static const ProtobufCIntRange planetmintgo__machine__query_get_machine_by_address_request__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 1 }
+};
+const ProtobufCMessageDescriptor planetmintgo__machine__query_get_machine_by_address_request__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "planetmintgo.machine.QueryGetMachineByAddressRequest",
+  "QueryGetMachineByAddressRequest",
+  "Planetmintgo__Machine__QueryGetMachineByAddressRequest",
+  "planetmintgo.machine",
+  sizeof(Planetmintgo__Machine__QueryGetMachineByAddressRequest),
+  1,
+  planetmintgo__machine__query_get_machine_by_address_request__field_descriptors,
+  planetmintgo__machine__query_get_machine_by_address_request__field_indices_by_name,
+  1,  planetmintgo__machine__query_get_machine_by_address_request__number_ranges,
+  (ProtobufCMessageInit) planetmintgo__machine__query_get_machine_by_address_request__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor planetmintgo__machine__query_get_machine_by_address_response__field_descriptors[1] =
+{
+  {
+    "machine",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    0,   /* quantifier_offset */
+    offsetof(Planetmintgo__Machine__QueryGetMachineByAddressResponse, machine),
+    &planetmintgo__machine__machine__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned planetmintgo__machine__query_get_machine_by_address_response__field_indices_by_name[] = {
+  0,   /* field[0] = machine */
+};
+static const ProtobufCIntRange planetmintgo__machine__query_get_machine_by_address_response__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 1 }
+};
+const ProtobufCMessageDescriptor planetmintgo__machine__query_get_machine_by_address_response__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "planetmintgo.machine.QueryGetMachineByAddressResponse",
+  "QueryGetMachineByAddressResponse",
+  "Planetmintgo__Machine__QueryGetMachineByAddressResponse",
+  "planetmintgo.machine",
+  sizeof(Planetmintgo__Machine__QueryGetMachineByAddressResponse),
+  1,
+  planetmintgo__machine__query_get_machine_by_address_response__field_descriptors,
+  planetmintgo__machine__query_get_machine_by_address_response__field_indices_by_name,
+  1,  planetmintgo__machine__query_get_machine_by_address_response__number_ranges,
+  (ProtobufCMessageInit) planetmintgo__machine__query_get_machine_by_address_response__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCMethodDescriptor planetmintgo__machine__query__method_descriptors[4] =
 {
   { "Params", &planetmintgo__machine__query_params_request__descriptor, &planetmintgo__machine__query_params_response__descriptor },
   { "GetMachineByPublicKey", &planetmintgo__machine__query_get_machine_by_public_key_request__descriptor, &planetmintgo__machine__query_get_machine_by_public_key_response__descriptor },
+  { "GetTrustAnchorStatus", &planetmintgo__machine__query_get_trust_anchor_status_request__descriptor, &planetmintgo__machine__query_get_trust_anchor_status_response__descriptor },
+  { "GetMachineByAddress", &planetmintgo__machine__query_get_machine_by_address_request__descriptor, &planetmintgo__machine__query_get_machine_by_address_response__descriptor },
 };
 const unsigned planetmintgo__machine__query__method_indices_by_name[] = {
+  3,        /* GetMachineByAddress */
   1,        /* GetMachineByPublicKey */
+  2,        /* GetTrustAnchorStatus */
   0         /* Params */
 };
 const ProtobufCServiceDescriptor planetmintgo__machine__query__descriptor =
@@ -335,7 +684,7 @@ const ProtobufCServiceDescriptor planetmintgo__machine__query__descriptor =
   "Query",
   "Planetmintgo__Machine__Query",
   "planetmintgo.machine",
-  2,
+  4,
   planetmintgo__machine__query__method_descriptors,
   planetmintgo__machine__query__method_indices_by_name
 };
@@ -354,6 +703,22 @@ void planetmintgo__machine__query__get_machine_by_public_key(ProtobufCService *s
 {
   assert(service->descriptor == &planetmintgo__machine__query__descriptor);
   service->invoke(service, 1, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
+}
+void planetmintgo__machine__query__get_trust_anchor_status(ProtobufCService *service,
+                                                           const Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest *input,
+                                                           Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse_Closure closure,
+                                                           void *closure_data)
+{
+  assert(service->descriptor == &planetmintgo__machine__query__descriptor);
+  service->invoke(service, 2, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
+}
+void planetmintgo__machine__query__get_machine_by_address(ProtobufCService *service,
+                                                          const Planetmintgo__Machine__QueryGetMachineByAddressRequest *input,
+                                                          Planetmintgo__Machine__QueryGetMachineByAddressResponse_Closure closure,
+                                                          void *closure_data)
+{
+  assert(service->descriptor == &planetmintgo__machine__query__descriptor);
+  service->invoke(service, 3, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
 }
 void planetmintgo__machine__query__init (Planetmintgo__Machine__Query_Service *service,
                                          Planetmintgo__Machine__Query_ServiceDestroy destroy)

--- a/lib/default/rddl/src/planetmintgo/machine/query.pb-c.h
+++ b/lib/default/rddl/src/planetmintgo/machine/query.pb-c.h
@@ -24,6 +24,10 @@ typedef struct Planetmintgo__Machine__QueryParamsRequest Planetmintgo__Machine__
 typedef struct Planetmintgo__Machine__QueryParamsResponse Planetmintgo__Machine__QueryParamsResponse;
 typedef struct Planetmintgo__Machine__QueryGetMachineByPublicKeyRequest Planetmintgo__Machine__QueryGetMachineByPublicKeyRequest;
 typedef struct Planetmintgo__Machine__QueryGetMachineByPublicKeyResponse Planetmintgo__Machine__QueryGetMachineByPublicKeyResponse;
+typedef struct Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest;
+typedef struct Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse;
+typedef struct Planetmintgo__Machine__QueryGetMachineByAddressRequest Planetmintgo__Machine__QueryGetMachineByAddressRequest;
+typedef struct Planetmintgo__Machine__QueryGetMachineByAddressResponse Planetmintgo__Machine__QueryGetMachineByAddressResponse;
 
 
 /* --- enums --- */
@@ -76,6 +80,47 @@ struct  Planetmintgo__Machine__QueryGetMachineByPublicKeyResponse
 };
 #define PLANETMINTGO__MACHINE__QUERY_GET_MACHINE_BY_PUBLIC_KEY_RESPONSE__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&planetmintgo__machine__query_get_machine_by_public_key_response__descriptor) \
+    , NULL }
+
+
+struct  Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest
+{
+  ProtobufCMessage base;
+  char *machineid;
+};
+#define PLANETMINTGO__MACHINE__QUERY_GET_TRUST_ANCHOR_STATUS_REQUEST__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&planetmintgo__machine__query_get_trust_anchor_status_request__descriptor) \
+    , (char *)protobuf_c_empty_string }
+
+
+struct  Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse
+{
+  ProtobufCMessage base;
+  char *machineid;
+  protobuf_c_boolean isactivated;
+};
+#define PLANETMINTGO__MACHINE__QUERY_GET_TRUST_ANCHOR_STATUS_RESPONSE__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&planetmintgo__machine__query_get_trust_anchor_status_response__descriptor) \
+    , (char *)protobuf_c_empty_string, 0 }
+
+
+struct  Planetmintgo__Machine__QueryGetMachineByAddressRequest
+{
+  ProtobufCMessage base;
+  char *address;
+};
+#define PLANETMINTGO__MACHINE__QUERY_GET_MACHINE_BY_ADDRESS_REQUEST__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&planetmintgo__machine__query_get_machine_by_address_request__descriptor) \
+    , (char *)protobuf_c_empty_string }
+
+
+struct  Planetmintgo__Machine__QueryGetMachineByAddressResponse
+{
+  ProtobufCMessage base;
+  Planetmintgo__Machine__Machine *machine;
+};
+#define PLANETMINTGO__MACHINE__QUERY_GET_MACHINE_BY_ADDRESS_RESPONSE__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&planetmintgo__machine__query_get_machine_by_address_response__descriptor) \
     , NULL }
 
 
@@ -155,6 +200,82 @@ Planetmintgo__Machine__QueryGetMachineByPublicKeyResponse *
 void   planetmintgo__machine__query_get_machine_by_public_key_response__free_unpacked
                      (Planetmintgo__Machine__QueryGetMachineByPublicKeyResponse *message,
                       ProtobufCAllocator *allocator);
+/* Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest methods */
+void   planetmintgo__machine__query_get_trust_anchor_status_request__init
+                     (Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest         *message);
+size_t planetmintgo__machine__query_get_trust_anchor_status_request__get_packed_size
+                     (const Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest   *message);
+size_t planetmintgo__machine__query_get_trust_anchor_status_request__pack
+                     (const Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest   *message,
+                      uint8_t             *out);
+size_t planetmintgo__machine__query_get_trust_anchor_status_request__pack_to_buffer
+                     (const Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest   *message,
+                      ProtobufCBuffer     *buffer);
+Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest *
+       planetmintgo__machine__query_get_trust_anchor_status_request__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   planetmintgo__machine__query_get_trust_anchor_status_request__free_unpacked
+                     (Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest *message,
+                      ProtobufCAllocator *allocator);
+/* Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse methods */
+void   planetmintgo__machine__query_get_trust_anchor_status_response__init
+                     (Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse         *message);
+size_t planetmintgo__machine__query_get_trust_anchor_status_response__get_packed_size
+                     (const Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse   *message);
+size_t planetmintgo__machine__query_get_trust_anchor_status_response__pack
+                     (const Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse   *message,
+                      uint8_t             *out);
+size_t planetmintgo__machine__query_get_trust_anchor_status_response__pack_to_buffer
+                     (const Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse   *message,
+                      ProtobufCBuffer     *buffer);
+Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse *
+       planetmintgo__machine__query_get_trust_anchor_status_response__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   planetmintgo__machine__query_get_trust_anchor_status_response__free_unpacked
+                     (Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse *message,
+                      ProtobufCAllocator *allocator);
+/* Planetmintgo__Machine__QueryGetMachineByAddressRequest methods */
+void   planetmintgo__machine__query_get_machine_by_address_request__init
+                     (Planetmintgo__Machine__QueryGetMachineByAddressRequest         *message);
+size_t planetmintgo__machine__query_get_machine_by_address_request__get_packed_size
+                     (const Planetmintgo__Machine__QueryGetMachineByAddressRequest   *message);
+size_t planetmintgo__machine__query_get_machine_by_address_request__pack
+                     (const Planetmintgo__Machine__QueryGetMachineByAddressRequest   *message,
+                      uint8_t             *out);
+size_t planetmintgo__machine__query_get_machine_by_address_request__pack_to_buffer
+                     (const Planetmintgo__Machine__QueryGetMachineByAddressRequest   *message,
+                      ProtobufCBuffer     *buffer);
+Planetmintgo__Machine__QueryGetMachineByAddressRequest *
+       planetmintgo__machine__query_get_machine_by_address_request__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   planetmintgo__machine__query_get_machine_by_address_request__free_unpacked
+                     (Planetmintgo__Machine__QueryGetMachineByAddressRequest *message,
+                      ProtobufCAllocator *allocator);
+/* Planetmintgo__Machine__QueryGetMachineByAddressResponse methods */
+void   planetmintgo__machine__query_get_machine_by_address_response__init
+                     (Planetmintgo__Machine__QueryGetMachineByAddressResponse         *message);
+size_t planetmintgo__machine__query_get_machine_by_address_response__get_packed_size
+                     (const Planetmintgo__Machine__QueryGetMachineByAddressResponse   *message);
+size_t planetmintgo__machine__query_get_machine_by_address_response__pack
+                     (const Planetmintgo__Machine__QueryGetMachineByAddressResponse   *message,
+                      uint8_t             *out);
+size_t planetmintgo__machine__query_get_machine_by_address_response__pack_to_buffer
+                     (const Planetmintgo__Machine__QueryGetMachineByAddressResponse   *message,
+                      ProtobufCBuffer     *buffer);
+Planetmintgo__Machine__QueryGetMachineByAddressResponse *
+       planetmintgo__machine__query_get_machine_by_address_response__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   planetmintgo__machine__query_get_machine_by_address_response__free_unpacked
+                     (Planetmintgo__Machine__QueryGetMachineByAddressResponse *message,
+                      ProtobufCAllocator *allocator);
 /* --- per-message closures --- */
 
 typedef void (*Planetmintgo__Machine__QueryParamsRequest_Closure)
@@ -168,6 +289,18 @@ typedef void (*Planetmintgo__Machine__QueryGetMachineByPublicKeyRequest_Closure)
                   void *closure_data);
 typedef void (*Planetmintgo__Machine__QueryGetMachineByPublicKeyResponse_Closure)
                  (const Planetmintgo__Machine__QueryGetMachineByPublicKeyResponse *message,
+                  void *closure_data);
+typedef void (*Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest_Closure)
+                 (const Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest *message,
+                  void *closure_data);
+typedef void (*Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse_Closure)
+                 (const Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse *message,
+                  void *closure_data);
+typedef void (*Planetmintgo__Machine__QueryGetMachineByAddressRequest_Closure)
+                 (const Planetmintgo__Machine__QueryGetMachineByAddressRequest *message,
+                  void *closure_data);
+typedef void (*Planetmintgo__Machine__QueryGetMachineByAddressResponse_Closure)
+                 (const Planetmintgo__Machine__QueryGetMachineByAddressResponse *message,
                   void *closure_data);
 
 /* --- services --- */
@@ -184,6 +317,14 @@ struct Planetmintgo__Machine__Query_Service
                                     const Planetmintgo__Machine__QueryGetMachineByPublicKeyRequest *input,
                                     Planetmintgo__Machine__QueryGetMachineByPublicKeyResponse_Closure closure,
                                     void *closure_data);
+  void (*get_trust_anchor_status)(Planetmintgo__Machine__Query_Service *service,
+                                  const Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest *input,
+                                  Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse_Closure closure,
+                                  void *closure_data);
+  void (*get_machine_by_address)(Planetmintgo__Machine__Query_Service *service,
+                                 const Planetmintgo__Machine__QueryGetMachineByAddressRequest *input,
+                                 Planetmintgo__Machine__QueryGetMachineByAddressResponse_Closure closure,
+                                 void *closure_data);
 };
 typedef void (*Planetmintgo__Machine__Query_ServiceDestroy)(Planetmintgo__Machine__Query_Service *);
 void planetmintgo__machine__query__init (Planetmintgo__Machine__Query_Service *service,
@@ -193,7 +334,9 @@ void planetmintgo__machine__query__init (Planetmintgo__Machine__Query_Service *s
 #define PLANETMINTGO__MACHINE__QUERY__INIT(function_prefix__) \
     { PLANETMINTGO__MACHINE__QUERY__BASE_INIT,\
       function_prefix__ ## params,\
-      function_prefix__ ## get_machine_by_public_key  }
+      function_prefix__ ## get_machine_by_public_key,\
+      function_prefix__ ## get_trust_anchor_status,\
+      function_prefix__ ## get_machine_by_address  }
 void planetmintgo__machine__query__params(ProtobufCService *service,
                                           const Planetmintgo__Machine__QueryParamsRequest *input,
                                           Planetmintgo__Machine__QueryParamsResponse_Closure closure,
@@ -202,6 +345,14 @@ void planetmintgo__machine__query__get_machine_by_public_key(ProtobufCService *s
                                                              const Planetmintgo__Machine__QueryGetMachineByPublicKeyRequest *input,
                                                              Planetmintgo__Machine__QueryGetMachineByPublicKeyResponse_Closure closure,
                                                              void *closure_data);
+void planetmintgo__machine__query__get_trust_anchor_status(ProtobufCService *service,
+                                                           const Planetmintgo__Machine__QueryGetTrustAnchorStatusRequest *input,
+                                                           Planetmintgo__Machine__QueryGetTrustAnchorStatusResponse_Closure closure,
+                                                           void *closure_data);
+void planetmintgo__machine__query__get_machine_by_address(ProtobufCService *service,
+                                                          const Planetmintgo__Machine__QueryGetMachineByAddressRequest *input,
+                                                          Planetmintgo__Machine__QueryGetMachineByAddressResponse_Closure closure,
+                                                          void *closure_data);
 
 /* --- descriptors --- */
 
@@ -209,6 +360,10 @@ extern const ProtobufCMessageDescriptor planetmintgo__machine__query_params_requ
 extern const ProtobufCMessageDescriptor planetmintgo__machine__query_params_response__descriptor;
 extern const ProtobufCMessageDescriptor planetmintgo__machine__query_get_machine_by_public_key_request__descriptor;
 extern const ProtobufCMessageDescriptor planetmintgo__machine__query_get_machine_by_public_key_response__descriptor;
+extern const ProtobufCMessageDescriptor planetmintgo__machine__query_get_trust_anchor_status_request__descriptor;
+extern const ProtobufCMessageDescriptor planetmintgo__machine__query_get_trust_anchor_status_response__descriptor;
+extern const ProtobufCMessageDescriptor planetmintgo__machine__query_get_machine_by_address_request__descriptor;
+extern const ProtobufCMessageDescriptor planetmintgo__machine__query_get_machine_by_address_response__descriptor;
 extern const ProtobufCServiceDescriptor planetmintgo__machine__query__descriptor;
 
 PROTOBUF_C__END_DECLS

--- a/lib/default/rddl/src/rddl.h
+++ b/lib/default/rddl/src/rddl.h
@@ -42,10 +42,9 @@ bool getSeedFromMnemonic( const char* pMnemonic, size_t len, uint8_t* seedbuffer
 bool getKeyFromSeed( const uint8_t* seed, uint8_t* priv_key, uint8_t* pub_key, const char* curve_name);
 
 bool SignDataHash(const char* data_str, size_t data_length, char* pubkey_out, char* sig_out, char* hash_out);
-
 int SignDataHashWithPrivKey(const uint8_t* digest, const uint8_t* priv_key, char* sig_out);
-
 bool verifyDataHash(const char* sig_str, const char* pub_key_str, const char* hash_str);
+
 
 bool getMachineIDSignature(  uint8_t* priv_key,  uint8_t* pub_key, uint8_t* signature, uint8_t* hash);
 

--- a/lib/default/rddl/src/rddl_types.h
+++ b/lib/default/rddl/src/rddl_types.h
@@ -11,6 +11,7 @@
 #define RDDL_MACHINE_CONTROLLER         7
 #define RDDL_MACHINE_CHARGER            8
 #define RDDL_MACHINE_BMS                9 
-#define RDDL_MACHINE_ESS               10 
+#define RDDL_MACHINE_ESS               10
+
 
 #endif

--- a/tasmota/tasmota_xdrv_driver/xdrv_129_rddl_network.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_129_rddl_network.ino
@@ -608,6 +608,7 @@ int registerMachine(void* anyMsg){
   machine.metadata = &metadata;
   machine.type = RDDL_MACHINE_POWER_SWITCH;
   machine.machineidsignature = signature_hex;
+  machine.address = (char*)g_address;
  
   Planetmintgo__Machine__MsgAttestMachine machineMsg = PLANETMINTGO__MACHINE__MSG_ATTEST_MACHINE__INIT;
   machineMsg.creator = (char*)g_address;
@@ -701,7 +702,7 @@ void runRDDLNotarizationWorkflow(const char* data_str, size_t data_length){
     Serial.println("Notarize: CID Asset\n");
     ResponseAppend_P("Notarize: CID Asset %s\n", cid_str);
 
-    generateAnyCIDAttestMsgGeneric(&anyMsg, cid_str, g_priv_key_planetmint, g_pub_key_planetmint, g_address, g_ext_pub_key_planetmint );
+    generateAnyCIDAttestMsg(&anyMsg, cid_str, g_priv_key_planetmint, g_pub_key_planetmint, g_address, g_ext_pub_key_planetmint );
   }
   else{
     Serial.println("Register: Machine\n");


### PR DESCRIPTION
* removed obsolete asset notarization objects and renamed one attribute, thereby adjusting to the newest planetmint API
* removed obsolete methods
* adjusted to the stricter anti-handler conditions by defining the machine.address field