### PR TITLE
Align plmnt address generation with planetmint-god

### DIFF
--- a/lib/default/rddl/src/rddl.c
+++ b/lib/default/rddl/src/rddl.c
@@ -87,7 +87,7 @@ const char* setSeed( char* pMnemonic, size_t len )
   if( !mnemonic_check( pMnemonic ) )
     return "";
 
-  mnemonic_to_seed(pMnemonic, "TREZOR", secret_seed, 0);
+  mnemonic_to_seed(pMnemonic, "", secret_seed, 0);
   return (const char*)pMnemonic;
 }
 
@@ -105,7 +105,7 @@ bool getSeedFromMnemonic( const char* pMnemonic, size_t len, uint8_t* seedbuffer
   if( !mnemonic_check( pMnemonic ) )
     return false;
   
-  mnemonic_to_seed(pMnemonic, "TREZOR", seedbuffer, NULL);
+  mnemonic_to_seed(pMnemonic, "", seedbuffer, NULL);
   return true;  
 }
 


### PR DESCRIPTION
Given the mnemonic:
```
addict man tonight icon dad sample grid sing romance wine expose guilt
```
planetmint-god creates:
- `plmnt1ned2dqrm26d04m2zqpmpljfgwjr8zg95u9w2qn` whereas Tasmota creates:
- `plmnt1smaptx4vm4p5wg76zvr9kn5l38l5fzh0gxf0pu`

Turns out this is due to different seeding. In Tasmota we provide `TREZOR` as password and in planetmint-god we do not.

Both implementations prefix the password with the string `mnemonic`, in planetmint-god:
```
func NewSeed(mnemonic string, password string) []byte {
	return pbkdf2.Key([]byte(mnemonic), []byte("mnemonic"+password), 2048, 64, sha512.New)
}
```
and in Tasmota:
```
lib/default/trezor-crypto/bip39.c:231:  memcpy(salt, "mnemonic", 8);
```

Removing the password in Tasmota creates the same plmnt address as in planetmint-god.

// Closes https://github.com/rddl-network/issues/issues/47